### PR TITLE
restore vscode autoformat settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.formatOnPaste": true,
+    "editor.formatOnType": true,
+    "editor.formatOnSave": true
+}


### PR DESCRIPTION
i swear format on save was enabled before nx conversion, either way this fixes it.