### PR TITLE
tests(adds tests, 100% code coverage for core)

### DIFF
--- a/libs/core/src/lib/effect.spec.ts
+++ b/libs/core/src/lib/effect.spec.ts
@@ -75,6 +75,40 @@ it('spawns an effect that spawns a child effect', () => {
   });
 });
 
+it('numbers the child effects', () => {
+  const effect: Effect<{}> = ({ spawnEffect }) => {
+    spawnEffect(() => of(), { name: 'child' });
+    spawnEffect(() => of(), { name: 'child' });
+    spawnEffect(() => of(), { name: 'child' });
+    return of();
+  };
+  setup({ value: {}, effect }, ({ expectObservable, effect$, storeEvent$ }) => {
+    expectObservable(effect$).toBe('|');
+    expectObservable(storeEvent$).toBe('(abcdefgh)', {
+      a: { event: 'spawn', name: 'root', type: 'effect' },
+      b: { event: 'spawn', name: 'child', type: 'effect' },
+      c: {
+        from: { name: 'child', type: 'effect' },
+        to: { name: 'root', type: 'effect' },
+        type: 'link',
+      },
+      d: { event: 'spawn', name: 'child2', type: 'effect' },
+      e: {
+        from: { name: 'child2', type: 'effect' },
+        to: { name: 'root', type: 'effect' },
+        type: 'link',
+      },
+      f: { event: 'spawn', name: 'child3', type: 'effect' },
+      g: {
+        from: { name: 'child3', type: 'effect' },
+        to: { name: 'root', type: 'effect' },
+        type: 'link',
+      },
+      h: { event: 'teardown', name: 'root', type: 'effect' },
+    });
+  });
+});
+
 it('spawns an effect that spawns grand children effects', () => {
   const grandchild: Effect<{}> = () => {
     return of();

--- a/libs/core/src/lib/effect.spec.ts
+++ b/libs/core/src/lib/effect.spec.ts
@@ -1,3 +1,54 @@
-it('', () => {
-  expect(true).toBe(true);
+import { of, ReplaySubject, timer, Observable } from 'rxjs';
+import { spawnRootEffect } from './effect';
+import { Effect, RootEffectArgs } from '..';
+import { TestScheduler } from 'rxjs/testing';
+import { StoreValue } from './store-value';
+import { StoreEvent } from './store-arg';
+
+interface CallbackArgs {
+  expectObservable: typeof TestScheduler.prototype.expectObservable;
+  storeEvent$: Observable<StoreEvent>;
+  effect$: Observable<unknown>;
+}
+
+const setup = <T extends StoreValue>(
+  args: RootEffectArgs<T>,
+  cb: (args: CallbackArgs) => void
+) => {
+  const storeEvent$ = new ReplaySubject<StoreEvent>();
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+  const effect$ = spawnRootEffect<T>({ ...args, observer: storeEvent$ });
+  testScheduler.run(({ expectObservable }) => {
+    cb({ expectObservable, storeEvent$, effect$ });
+  });
+};
+
+it('spawns and tears down an empty effect', () => {
+  const effect: Effect<{}> = () => of();
+  setup({ value: {}, effect }, ({ expectObservable, effect$, storeEvent$ }) => {
+    expectObservable(effect$).toBe('|');
+    expectObservable(storeEvent$).toBe('(ab)', {
+      a: { event: 'spawn', name: 'root', type: 'effect' },
+      b: { event: 'teardown', name: 'root', type: 'effect' },
+    });
+  });
+});
+
+it('spawns and tears down an effect with a timer', () => {
+  const effect: Effect<{}> = () => timer(10);
+  setup({ value: {}, effect }, ({ expectObservable, effect$, storeEvent$ }) => {
+    expectObservable(effect$).toBe('----------(a|)', { a: 0 });
+    expectObservable(storeEvent$).toBe('  a---------(bc)', {
+      a: { event: 'spawn', name: 'root', type: 'effect' },
+      b: {
+        type: 'value',
+        from: { name: '', type: 'effect' },
+        to: { name: 'root', type: 'effect' },
+        value: 0,
+      },
+      c: { event: 'teardown', name: 'root', type: 'effect' },
+    });
+  });
 });

--- a/libs/core/src/lib/effect.spec.ts
+++ b/libs/core/src/lib/effect.spec.ts
@@ -1,31 +1,6 @@
-import { of, ReplaySubject, timer, Observable } from 'rxjs';
-import { spawnRootEffect } from './effect';
-import { Effect, RootEffectArgs, resetIds } from '..';
-import { TestScheduler } from 'rxjs/testing';
-import { StoreValue } from './store-value';
-import { StoreEvent } from './store-arg';
-import { toArray, take, takeUntil } from 'rxjs/operators';
-
-interface CallbackArgs {
-  expectObservable: typeof TestScheduler.prototype.expectObservable;
-  storeEvent$: Observable<StoreEvent>;
-  effect$: Observable<unknown>;
-}
-
-const setup = <T extends StoreValue>(
-  args: RootEffectArgs<T>,
-  cb: (args: CallbackArgs) => void
-) => {
-  resetIds();
-  const storeEvent$ = new ReplaySubject<StoreEvent>();
-  const testScheduler = new TestScheduler((actual, expected) => {
-    expect(actual).toEqual(expected);
-  });
-  const effect$ = spawnRootEffect<T>({ ...args, observer: storeEvent$ });
-  testScheduler.run(({ expectObservable }) => {
-    cb({ expectObservable, storeEvent$, effect$ });
-  });
-};
+import { of, timer } from 'rxjs';
+import { Effect } from './effect';
+import { setup } from './test-helper';
 
 it('spawns and tears down an empty effect', () => {
   const effect: Effect<{}> = () => of();

--- a/libs/core/src/lib/effect.ts
+++ b/libs/core/src/lib/effect.ts
@@ -151,8 +151,5 @@ export const spawnRootEffect = <T extends StoreValue>({
       event: 'spawn',
     });
   }
-  if (!effect) {
-    return Observable.create();
-  }
   return spawnEffect(effect, ['root']);
 };

--- a/libs/core/src/lib/effect.ts
+++ b/libs/core/src/lib/effect.ts
@@ -41,6 +41,11 @@ export interface RootEffectArgs<T extends StoreValue> {
 }
 
 const ids: Record<string, number> = {};
+export const resetIds = () => {
+  Object.keys(ids).forEach((key) => {
+    delete ids[key];
+  });
+};
 
 /**
  * The spawnRootEffect runs the root effect which means the effectFn is called

--- a/libs/core/src/lib/sinks.spec.ts
+++ b/libs/core/src/lib/sinks.spec.ts
@@ -1,0 +1,35 @@
+import { Subject, of } from 'rxjs';
+import { Effect } from './effect';
+import { setup } from './test-helper';
+
+it('sources data from subject', () => {
+  const value = { count$: new Subject() };
+  const effect: Effect<typeof value> = ({ sinks }) => {
+    return of('hello world').pipe(sinks.count$());
+  };
+  setup({ value, effect }, ({ expectObservable, effect$, storeEvent$ }) => {
+    expectObservable(effect$).toBe('(a|)', { a: 'hello world' });
+
+    expectObservable(storeEvent$).toBe('(abcde)', {
+      a: { type: 'effect', name: 'root', event: 'spawn' },
+      b: {
+        type: 'link',
+        to: { type: 'subject', name: 'count$' },
+        from: { type: 'effect', name: 'root' },
+      },
+      c: {
+        type: 'value',
+        to: { type: 'subject', name: 'count$' },
+        from: { type: 'effect', name: 'root' },
+        value: 'hello world',
+      },
+      d: {
+        type: 'value',
+        to: { type: 'effect', name: 'root' },
+        from: { type: 'effect', name: '' },
+        value: 'hello world',
+      },
+      e: { type: 'effect', event: 'teardown', name: 'root' },
+    });
+  });
+});

--- a/libs/core/src/lib/sources.spec.ts
+++ b/libs/core/src/lib/sources.spec.ts
@@ -1,0 +1,40 @@
+import { Subject } from 'rxjs';
+import { Effect } from './effect';
+import { setup } from './test-helper';
+
+it('sources data from subject', () => {
+  const value = { count$: new Subject() };
+  const effect: Effect<typeof value> = ({ sources }) => {
+    return sources.count$();
+  };
+  setup(
+    { value, effect },
+    ({ expectObservable, effect$, hot, storeEvent$ }) => {
+      // hack to emit mocked values onto the subject in the store value
+      // TODO - i don't understand why changing to "cold" breaks test?
+      hot('a').subscribe(value.count$);
+
+      expectObservable(effect$).toBe('a');
+      expectObservable(storeEvent$).toBe('(abcd)', {
+        a: { type: 'effect', name: 'root', event: 'spawn' },
+        b: {
+          type: 'link',
+          from: { type: 'subject', name: 'count$' },
+          to: { type: 'effect', name: 'root' },
+        },
+        c: {
+          type: 'value',
+          from: { type: 'subject', name: 'count$' },
+          to: { type: 'effect', name: 'root' },
+          value: 'a',
+        },
+        d: {
+          type: 'value',
+          to: { type: 'effect', name: 'root' },
+          from: { type: 'effect', name: '' },
+          value: 'a',
+        },
+      });
+    }
+  );
+});

--- a/libs/core/src/lib/sources.spec.ts
+++ b/libs/core/src/lib/sources.spec.ts
@@ -10,8 +10,6 @@ it('sources data from subject', () => {
   setup(
     { value, effect },
     ({ expectObservable, effect$, hot, storeEvent$ }) => {
-      // hack to emit mocked values onto the subject in the store value
-      // TODO - i don't understand why changing to "cold" breaks test?
       hot('a').subscribe(value.count$);
 
       expectObservable(effect$).toBe('a');

--- a/libs/core/src/lib/test-helper.ts
+++ b/libs/core/src/lib/test-helper.ts
@@ -1,0 +1,28 @@
+import { expect } from '@jest/globals';
+import { ReplaySubject, Observable } from 'rxjs';
+import { spawnRootEffect } from './effect';
+import { RootEffectArgs, resetIds } from '..';
+import { TestScheduler } from 'rxjs/testing';
+import { StoreValue } from './store-value';
+import { StoreEvent } from './store-arg';
+
+interface CallbackArgs {
+  expectObservable: typeof TestScheduler.prototype.expectObservable;
+  storeEvent$: Observable<StoreEvent>;
+  effect$: Observable<unknown>;
+}
+
+export const setup = <T extends StoreValue>(
+  args: RootEffectArgs<T>,
+  cb: (args: CallbackArgs) => void
+) => {
+  resetIds();
+  const storeEvent$ = new ReplaySubject<StoreEvent>();
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+  const effect$ = spawnRootEffect<T>({ ...args, observer: storeEvent$ });
+  testScheduler.run(({ expectObservable }) => {
+    cb({ expectObservable, storeEvent$, effect$ });
+  });
+};

--- a/libs/core/src/lib/test-helper.ts
+++ b/libs/core/src/lib/test-helper.ts
@@ -5,15 +5,15 @@ import { RootEffectArgs, resetIds } from '..';
 import { TestScheduler } from 'rxjs/testing';
 import { StoreValue } from './store-value';
 import { StoreEvent } from './store-arg';
+import { RunHelpers } from 'rxjs/internal/testing/TestScheduler';
 
-interface CallbackArgs {
-  expectObservable: typeof TestScheduler.prototype.expectObservable;
+interface CallbackArgs extends RunHelpers {
   storeEvent$: Observable<StoreEvent>;
   effect$: Observable<unknown>;
 }
 
 export const setup = <T extends StoreValue>(
-  args: RootEffectArgs<T>,
+  setupArgs: RootEffectArgs<T>,
   cb: (args: CallbackArgs) => void
 ) => {
   resetIds();
@@ -21,8 +21,8 @@ export const setup = <T extends StoreValue>(
   const testScheduler = new TestScheduler((actual, expected) => {
     expect(actual).toEqual(expected);
   });
-  const effect$ = spawnRootEffect<T>({ ...args, observer: storeEvent$ });
-  testScheduler.run(({ expectObservable }) => {
-    cb({ expectObservable, storeEvent$, effect$ });
+  const effect$ = spawnRootEffect<T>({ ...setupArgs, observer: storeEvent$ });
+  testScheduler.run((runHelpers) => {
+    cb({ ...runHelpers, storeEvent$, effect$ });
   });
 };


### PR DESCRIPTION
- Adds tests (progress against #56).
- Please review & merge #48 first, then change this PR to use `master` as the base before reviewing it (this depends on changes introduced is the `visualizer` branch, namely the addition of the "store events" and the ability to observe the inner workings of the store, which I verify with these tests).